### PR TITLE
Add affiliate links for various activities

### DIFF
--- a/index.html
+++ b/index.html
@@ -635,7 +635,7 @@
                         title: 'コナミスポーツクラブ ベビースイミング',
                         description: '全国展開の安心のベビースイミング教室',
                         imageUrl: 'https://via.placeholder.com/300x150/4f46e5/white?text=コナミスポーツクラブ',
-                        affiliateUrl: 'https://example.com/konami-baby-swimming',
+                        affiliateUrl: 'https://www.konami.com/sportsclub/child/',
                         price: '月額7,500円〜',
                         features: ['全国200店舗', '経験豊富なインストラクター', '親子で安心']
                     },
@@ -643,7 +643,7 @@
                         title: 'セントラルスポーツ ママベビコース',
                         description: '0歳から始められるベビースイミング専門',
                         imageUrl: 'https://via.placeholder.com/300x150/059669/white?text=セントラルスポーツ',
-                        affiliateUrl: 'https://example.com/central-baby-swimming',
+                        affiliateUrl: 'https://www.central.co.jp/',
                         price: '月額6,800円〜',
                         features: ['専用プール', '少人数制', '無料体験あり']
                     }
@@ -667,7 +667,7 @@
                         title: 'ベビーマッサージ教室 momo',
                         description: '助産師による安心のベビーマッサージ',
                         imageUrl: 'https://via.placeholder.com/300x150/ec4899/white?text=ベビーマッサージmomo',
-                        affiliateUrl: 'https://example.com/baby-massage-momo',
+                        affiliateUrl: 'https://babymassage-momo.com/',
                         price: '1回3,500円〜',
                         features: ['助産師指導', '個別対応', '出張レッスン可']
                     },
@@ -675,7 +675,7 @@
                         title: 'カルチャーセンター ベビーマッサージ',
                         description: '全国のカルチャーセンターで開催',
                         imageUrl: 'https://via.placeholder.com/300x150/8b5cf6/white?text=カルチャーセンター',
-                        affiliateUrl: 'https://example.com/culture-center-massage',
+                        affiliateUrl: 'https://www.culture.gr.jp/',
                         price: '月額4,000円〜',
                         features: ['全国展開', 'グループレッスン', '親子の交流']
                     }
@@ -693,7 +693,25 @@
                 traits: ['intellectual', 'auditory'],
                 difficulty: 'easy',
                 continuity_rate: 75,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: 'ヒューマンアカデミー ロボット教室',
+                        description: '全国展開のロボット・プログラミング教室',
+                        imageUrl: 'https://via.placeholder.com/300x150/f59e0b/white?text=ヒューマンロボット',
+                        affiliateUrl: 'https://kids.athuman.com/robot/',
+                        price: '月額10,000円〜',
+                        features: ['全国1,500教室', '教材レンタル', '大会参加']
+                    },
+                    {
+                        title: 'ロボ団',
+                        description: '実践的なロボット製作とプログラミング',
+                        imageUrl: 'https://via.placeholder.com/300x150/3b82f6/white?text=ロボ団',
+                        affiliateUrl: 'https://robo-done.com/',
+                        price: '月額11,000円〜',
+                        features: ['STEAM教育', '少人数制', '体験会あり']
+                    }
+                ]
             },
             baby_yoga: {
                 name: 'ベビーヨガ',
@@ -721,7 +739,17 @@
                 traits: ['creative', 'auditory'],
                 difficulty: 'easy',
                 continuity_rate: 85,
-                future_potential: 'high'
+                future_potential: 'high',
+                affiliateBanners: [
+                    {
+                        title: 'デジタルハリウッド スクール',
+                        description: 'CGやデザインを学べる専門スクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/ef4444/white?text=DHW',
+                        affiliateUrl: 'https://school.dhw.co.jp/',
+                        price: '月額12,000円〜',
+                        features: ['プロ講師陣', 'オンライン対応', '作品制作']
+                    }
+                ]
             },
             toddler_gymnastics: {
                 name: '幼児体操',
@@ -777,7 +805,17 @@
                 traits: ['intellectual', 'curious'],
                 difficulty: 'medium',
                 continuity_rate: 70,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: 'SecHack365',
+                        description: '次世代を担うホワイトハッカー育成プログラム',
+                        imageUrl: 'https://via.placeholder.com/300x150/2563eb/white?text=SecHack365',
+                        affiliateUrl: 'https://sechack365.nict.go.jp/',
+                        price: '受講料無料',
+                        features: ['オンライン講義', '専門家指導', '成果発表会']
+                    }
+                ]
             },
             montessori: {
                 name: 'モンテッソーリ教育',
@@ -791,7 +829,17 @@
                 traits: ['intellectual', 'independent'],
                 difficulty: 'medium',
                 continuity_rate: 85,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: 'SIGNATE Quest',
+                        description: 'データサイエンスをゲーム感覚で学べるサービス',
+                        imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=SIGNATE',
+                        affiliateUrl: 'https://quest.signate.jp/',
+                        price: '月額10,000円〜',
+                        features: ['実践課題', 'オンライン完結', 'レベル別学習']
+                    }
+                ]
             },
             waldorf: {
                 name: 'シュタイナー教育',
@@ -825,7 +873,7 @@
                         title: '森のようちえん全国ネットワーク',
                         description: '自然体験を重視した保育を全国で展開',
                         imageUrl: 'https://via.placeholder.com/300x150/16a34a/white?text=森のようちえん',
-                        affiliateUrl: 'https://example.com/forest-kindergarten',
+                        affiliateUrl: 'https://morinoyouchien.org/',
                         price: '月額9,000円〜',
                         features: ['自然体験', '屋外活動', '少人数制']
                     }
@@ -851,7 +899,7 @@
                         title: 'QUREO（キュレオ）プログラミング教室',
                         description: '小学生のためのプログラミング教室No.1',
                         imageUrl: 'https://via.placeholder.com/300x150/8b5cf6/white?text=QUREO',
-                        affiliateUrl: 'https://example.com/qureo-programming',
+                        affiliateUrl: 'https://qureo.jp/',
                         price: '月額9,900円〜',
                         features: ['ゲーム感覚で学習', '個別指導', '全国2,500教室']
                     },
@@ -859,7 +907,7 @@
                         title: 'ヒューマンアカデミージュニア',
                         description: 'ロボット教室とプログラミング教室を展開',
                         imageUrl: 'https://via.placeholder.com/300x150/f59e0b/white?text=ヒューマンアカデミー',
-                        affiliateUrl: 'https://example.com/human-academy-junior',
+                        affiliateUrl: 'https://kids.athuman.com/',
                         price: '月額10,890円〜',
                         features: ['ロボット製作', 'プログラミング', '全国1,600教室']
                     },
@@ -867,7 +915,7 @@
                         title: 'LITALICOワンダー',
                         description: 'IT×ものづくり教室でお子様の創造力を解放',
                         imageUrl: 'https://via.placeholder.com/300x150/ef4444/white?text=LITALICOワンダー',
-                        affiliateUrl: 'https://example.com/litalico-wonder',
+                        affiliateUrl: 'https://wonder.litalico.jp/',
                         price: '月額13,200円〜',
                         features: ['オーダーメイド授業', '少人数制', '無料体験授業']
                     }
@@ -885,7 +933,25 @@
                 traits: ['intellectual', 'kinesthetic'],
                 difficulty: 'hard',
                 continuity_rate: 70,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "ヒューマンアカデミー ロボット教室",
+                        description: "全国展開のロボット・プログラミング教室",
+                        imageUrl: "https://via.placeholder.com/300x150/f59e0b/white?text=ヒューマンロボット",
+                        affiliateUrl: "https://kids.athuman.com/robot/",
+                        price: "月額10,000円〜",
+                        features: ["全国1,500教室", "教材レンタル", "大会参加"]
+                    },
+                    {
+                        title: "エジソンアカデミー",
+                        description: "自考力と創造力を養う本格ロボット教材",
+                        imageUrl: "https://via.placeholder.com/300x150/3b82f6/white?text=エジソンアカデミー",
+                        affiliateUrl: "https://www.artec-kk.co.jp/",
+                        price: "月額11,000円〜",
+                        features: ["教材キット", "全国大会", "プログラミング学習"]
+                    }
+                ],
             },
             esports: {
                 name: 'eスポーツ',
@@ -905,7 +971,7 @@
                         title: 'eスポーツアカデミー',
                         description: 'プロゲーマーを目指す子供向け本格スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/2563eb/white?text=eスポーツアカデミー',
-                        affiliateUrl: 'https://example.com/esports-academy',
+                        affiliateUrl: 'https://esports-academy.jp/',
                         price: '月額12,000円〜',
                         features: ['プロ講師', '最新設備', '大会参加サポート']
                     }
@@ -929,7 +995,7 @@
                         title: 'ドローンスクールジャパン',
                         description: '国内最大規模のドローン専門スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/4b5563/white?text=DSJ',
-                        affiliateUrl: 'https://example.com/drone-school-japan',
+                        affiliateUrl: 'https://drone-school-japan.com/',
                         price: '月額15,000円〜',
                         features: ['国家資格対応', '空撮実習', '機体レンタル']
                     }
@@ -953,7 +1019,7 @@
                         title: '動画クリエイターズアカデミー',
                         description: 'YouTuberを目指す子供向け専門スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/ea580c/white?text=VCA',
-                        affiliateUrl: 'https://example.com/video-academy',
+                        affiliateUrl: 'https://vca.tokyo/',
                         price: '月額11,000円〜',
                         features: ['編集技術', '企画力育成', '発表会']
                     }
@@ -977,7 +1043,7 @@
                         title: 'Unityゲームクリエイター講座',
                         description: 'ゲーム開発に必須のUnityを学ぶ',
                         imageUrl: 'https://via.placeholder.com/300x150/047857/white?text=Unity\u8b1b\u5ea7',
-                        affiliateUrl: 'https://example.com/unity-game',
+                        affiliateUrl: 'https://unity.com/',
                         price: '月額15,000円〜',
                         features: ['本格カリキュラム', 'オンライン対応', '作品制作']
                     }
@@ -1009,7 +1075,17 @@
                 traits: ['creative', 'technology'],
                 difficulty: 'medium',
                 continuity_rate: 75,
-                future_potential: 'high'
+                future_potential: 'high',
+                affiliateBanners: [
+                    {
+                        title: "デジハリONLINE",
+                        description: "自宅で学べるデジタルアート講座",
+                        imageUrl: "https://via.placeholder.com/300x150/ef4444/white?text=デジハリONLINE",
+                        affiliateUrl: "https://online.dhw.co.jp/",
+                        price: "月額12,000円〜",
+                        features: ["プロ講師", "オンライン完結", "作品制作"]
+                    }
+                ],
             },
             cyber_security: {
                 name: 'サイバーセキュリティ',
@@ -1023,7 +1099,17 @@
                 traits: ['logical', 'careful'],
                 difficulty: 'hard',
                 continuity_rate: 70,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "セキュリティ・キャンプ",
+                        description: "IPA主催の高度セキュリティ講座",
+                        imageUrl: "https://via.placeholder.com/300x150/2563eb/white?text=SecurityCamp",
+                        affiliateUrl: "https://www.security-camp.or.jp/",
+                        price: "受講料無料",
+                        features: ["専門家指導", "実践演習", "全国合同"]
+                    }
+                ],
             },
             data_science_kids: {
                 name: 'キッズデータサイエンス',
@@ -1037,7 +1123,17 @@
                 traits: ['logical', 'analyst'],
                 difficulty: 'hard',
                 continuity_rate: 65,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "SIGNATE Quest",
+                        description: "データサイエンスをゲーム感覚で学習",
+                        imageUrl: "https://via.placeholder.com/300x150/10b981/white?text=SIGNATE",
+                        affiliateUrl: "https://quest.signate.jp/",
+                        price: "月額10,000円〜",
+                        features: ["実践課題", "オンライン完結", "レベル別学習"]
+                    }
+                ],
             },
             iot_electronics: {
                 name: 'IoT・電子工作',
@@ -1051,7 +1147,17 @@
                 traits: ['kinesthetic', 'logical'],
                 difficulty: 'medium',
                 continuity_rate: 75,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "Makeblock STEM Center",
+                        description: "ロボットや電子工作を総合的に学べる",
+                        imageUrl: "https://via.placeholder.com/300x150/facc15/white?text=Makeblock",
+                        affiliateUrl: "https://www.makeblock.com/",
+                        price: "月額12,000円〜",
+                        features: ["教材キット", "プロ講師", "大会参加"]
+                    }
+                ],
             },
             blockchain_kids: {
                 name: 'ブロックチェーン入門',
@@ -1065,7 +1171,17 @@
                 traits: ['logical', 'curious'],
                 difficulty: 'hard',
                 continuity_rate: 60,
-                future_potential: 'high'
+                future_potential: 'high',
+                affiliateBanners: [
+                    {
+                        title: "Blockchain Academy",
+                        description: "ブロックチェーン技術を基礎から学習",
+                        imageUrl: "https://via.placeholder.com/300x150/8b5cf6/white?text=Blockchain",
+                        affiliateUrl: "https://blockchainacademy.jp/",
+                        price: "月額15,000円〜",
+                        features: ["専門家講義", "実践演習", "将来性大"]
+                    }
+                ],
             },
             social_media_literacy: {
                 name: 'SNS・メディアリテラシー',
@@ -1079,7 +1195,17 @@
                 traits: ['social', 'logical'],
                 difficulty: 'medium',
                 continuity_rate: 80,
-                future_potential: 'high'
+                future_potential: 'high',
+                affiliateBanners: [
+                    {
+                        title: "Googleデジタルワークショップ",
+                        description: "オンラインで学べるメディアリテラシー",
+                        imageUrl: "https://via.placeholder.com/300x150/ea580c/white?text=Google",
+                        affiliateUrl: "https://learndigital.withgoogle.com/digitalworkshop-jp",
+                        price: "無料コースあり",
+                        features: ["動画教材", "修了証発行", "初心者向け"]
+                    }
+                ],
             },
             digital_marketing: {
                 name: 'デジタルマーケティング',
@@ -1093,7 +1219,17 @@
                 traits: ['social', 'analyst'],
                 difficulty: 'medium',
                 continuity_rate: 70,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "TechAcademy",
+                        description: "オンライン完結のマーケティング講座",
+                        imageUrl: "https://via.placeholder.com/300x150/3b82f6/white?text=TechAcademy",
+                        affiliateUrl: "https://techacademy.jp/",
+                        price: "月額15,000円〜",
+                        features: ["現役プロ講師", "メンタリング", "実践課題"]
+                    }
+                ],
             },
             tech_entrepreneurship: {
                 name: '起業・ビジネス創造',
@@ -1107,7 +1243,17 @@
                 traits: ['leader', 'creative'],
                 difficulty: 'hard',
                 continuity_rate: 75,
-                future_potential: 'very_high'
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: "StartupWeekend",
+                        description: "週末起業体験イベント",
+                        imageUrl: "https://via.placeholder.com/300x150/0ea5e9/white?text=StartupWeekend",
+                        affiliateUrl: "https://nposw.org/",
+                        price: "参加費1回数千円〜",
+                        features: ["実践型", "メンター指導", "チーム作業"]
+                    }
+                ],
             },
 
             // スポーツ・運動系 (30種類) - 年齢範囲を厳密に修正
@@ -1129,7 +1275,7 @@
                         title: 'リベルタサッカースクール',
                         description: '全国No.1のサッカースクール',
                         imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=リベルタサッカー',
-                        affiliateUrl: 'https://example.com/liberta-soccer',
+                        affiliateUrl: 'https://liberta-sports.com/',
                         price: '月額8,290円〜',
                         features: ['全国1,200箇所', '3歳から12歳', '無料体験実施中']
                     },
@@ -1137,7 +1283,7 @@
                         title: 'クーバー・コーチング',
                         description: '世界基準の個人技術指導',
                         imageUrl: 'https://via.placeholder.com/300x150/3b82f6/white?text=クーバーコーチング',
-                        affiliateUrl: 'https://example.com/coerver-coaching',
+                        affiliateUrl: 'https://coerver.co.jp/',
                         price: '月額7,700円〜',
                         features: ['個人技術特化', '世界30ヶ国で展開', '年齢別クラス']
                     }
@@ -1161,7 +1307,7 @@
                         title: 'コナミスポーツクラブ',
                         description: '全国展開の総合スポーツクラブ',
                         imageUrl: 'https://via.placeholder.com/300x150/4f46e5/white?text=コナミスポーツ',
-                        affiliateUrl: 'https://example.com/konami-swimming',
+                        affiliateUrl: 'https://www.konami.com/sportsclub/',
                         price: '月額8,800円〜',
                         features: ['全国200店舗', '年齢別クラス', '個人指導あり']
                     },
@@ -1169,7 +1315,7 @@
                         title: 'セントラルスポーツ',
                         description: '水泳専門指導で確実な上達',
                         imageUrl: 'https://via.placeholder.com/300x150/059669/white?text=セントラルスポーツ',
-                        affiliateUrl: 'https://example.com/central-swimming',
+                        affiliateUrl: 'https://www.central.co.jp/',
                         price: '月額7,700円〜',
                         features: ['段階別指導', '進級テスト', '選手育成コース']
                     },
@@ -1177,7 +1323,7 @@
                         title: 'ルネサンス スイミングスクール',
                         description: '科学的指導法で効率的な上達',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=ルネサンス',
-                        affiliateUrl: 'https://example.com/renaissance-swimming',
+                        affiliateUrl: 'https://www.s-re.jp/',
                         price: '月額8,250円〜',
                         features: ['科学的指導', '映像分析', '無料送迎バス']
                     }
@@ -1195,7 +1341,17 @@
                 traits: ['physical', 'logical'],
                 difficulty: 'medium',
                 continuity_rate: 80,
-                future_potential: 'medium'
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "ボーイズリーグ",
+                        description: "全国組織の少年野球チーム",
+                        imageUrl: "https://via.placeholder.com/300x150/f97316/white?text=ボーイズリーグ",
+                        affiliateUrl: "https://www.boysleague-jp.org/",
+                        price: "月額5,000円〜",
+                        features: ["公式大会", "指導者制度", "仲間との交流"]
+                    }
+                ],
             },
             tennis: {
                 name: 'テニス',
@@ -1209,7 +1365,17 @@
                 traits: ['physical', 'individual'],
                 difficulty: 'medium',
                 continuity_rate: 75,
-                future_potential: 'medium'
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "日本テニス協会公認スクール",
+                        description: "全国のテニススクール検索",
+                        imageUrl: "https://via.placeholder.com/300x150/ea580c/white?text=JTAスクール",
+                        affiliateUrl: "https://www.jta-tennis.or.jp/",
+                        price: "月額8,000円〜",
+                        features: ["公認コーチ", "大会参加", "レンタルコート"]
+                    }
+                ],
             },
             basketball: {
                 name: 'バスケットボール',
@@ -1223,9 +1389,18 @@
                 traits: ['physical', 'social'],
                 difficulty: 'medium',
                 continuity_rate: 80,
-                future_potential: 'medium'
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "バスケットボール協会クラブ",
+                        description: "JBA公認のジュニアクラブ",
+                        imageUrl: "https://via.placeholder.com/300x150/facc15/white?text=JBAクラブ",
+                        affiliateUrl: "https://www.japanbasketball.jp/",
+                        price: "月額5,000円〜",
+                        features: ["公式戦", "基礎から応用", "仲間と切磋琢磨"]
+                    }
+                ],
             },
-            // 追加の新しいスポーツ
             parkour: {
                 name: 'パルクール',
                 description: '都市環境を利用した自由な移動術',
@@ -1316,7 +1491,7 @@
                         title: '講道館柔道 認定道場',
                         description: '伝統ある講道館の認定を受けた正統派道場',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=講道館認定道場',
-                        affiliateUrl: 'https://example.com/kodokan-judo',
+                        affiliateUrl: 'https://kodokanjudoinstitute.org/',
                         price: '月額6,600円〜',
                         features: ['講道館認定', '段位取得可', '礼儀指導重視']
                     },
@@ -1324,7 +1499,7 @@
                         title: 'コナミスポーツクラブ 柔道スクール',
                         description: '安全で楽しく学べる柔道教室',
                         imageUrl: 'https://via.placeholder.com/300x150/4f46e5/white?text=コナミ柔道',
-                        affiliateUrl: 'https://example.com/konami-judo',
+                        affiliateUrl: 'https://www.konami.com/sportsclub/',
                         price: '月額8,250円〜',
                         features: ['安全指導', '年齢別クラス', '体験レッスン']
                     }
@@ -1378,7 +1553,7 @@
                         title: 'ヤマハ音楽教室',
                         description: '60年以上の実績を誇る音楽教室',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=ヤマハ音楽教室',
-                        affiliateUrl: 'https://example.com/yamaha-music',
+                        affiliateUrl: 'https://school.jp.yamaha.com/music-school/',
                         price: '月額7,500円〜',
                         features: ['グループレッスン', '1歳から', '全国1,200会場']
                     },
@@ -1386,7 +1561,7 @@
                         title: 'カワイ音楽教室',
                         description: '個人レッスンで確実な上達をサポート',
                         imageUrl: 'https://via.placeholder.com/300x150/7c3aed/white?text=カワイ音楽教室',
-                        affiliateUrl: 'https://example.com/kawai-music',
+                        affiliateUrl: 'https://music.kawai.jp/',
                         price: '月額8,250円〜',
                         features: ['個人レッスン', '3歳から', '無料体験レッスン']
                     },
@@ -1394,7 +1569,7 @@
                         title: 'EYS音楽教室',
                         description: '大人から子供まで楽しめる音楽教室',
                         imageUrl: 'https://via.placeholder.com/300x150/f97316/white?text=EYS音楽教室',
-                        affiliateUrl: 'https://example.com/eys-music',
+                        affiliateUrl: 'https://www.eys-musicschool.com/',
                         price: '月額12,120円〜',
                         features: ['楽器プレゼント', '補講無料', 'オールフリー制']
                     }
@@ -1418,7 +1593,7 @@
                         title: 'スズキ・メソード バイオリン教室',
                         description: '世界的に有名なスズキメソッドで指導',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=スズキメソッド',
-                        affiliateUrl: 'https://example.com/suzuki-violin',
+                        affiliateUrl: 'https://www.suzukimethod.or.jp/',
                         price: '月額12,000円〜',
                         features: ['スズキメソッド', '国際的指導法', '3歳から受講可']
                     },
@@ -1426,7 +1601,7 @@
                         title: '桐朋学園大学音楽学部附属 子供のための音楽教室',
                         description: '音大附属の本格的バイオリン教室',
                         imageUrl: 'https://via.placeholder.com/300x150/7c3aed/white?text=桐朋音楽教室',
-                        affiliateUrl: 'https://example.com/toho-violin',
+                        affiliateUrl: 'https://www.toho.ac.jp/',
                         price: '月額18,000円〜',
                         features: ['音大附属', 'プロ指導', '高度な技術習得']
                     }
@@ -1450,7 +1625,7 @@
                         title: 'ヤマハ音楽教室 ギターコース',
                         description: 'アコースティックからエレキまで対応',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=ヤマハギター',
-                        affiliateUrl: 'https://example.com/yamaha-guitar',
+                        affiliateUrl: 'https://school.jp.yamaha.com/music-school/guitar/',
                         price: '月額8,800円〜',
                         features: ['グループレッスン', '楽曲演奏重視', '全国1,200会場']
                     },
@@ -1458,7 +1633,7 @@
                         title: 'EYS音楽教室 ギター科',
                         description: 'ギタープレゼントの音楽教室',
                         imageUrl: 'https://via.placeholder.com/300x150/f97316/white?text=EYSギター',
-                        affiliateUrl: 'https://example.com/eys-guitar',
+                        affiliateUrl: 'https://www.eys-musicschool.com/',
                         price: '月額12,120円〜',
                         features: ['ギタープレゼント', '個人レッスン', '補講無料']
                     }
@@ -1498,7 +1673,7 @@
                         title: 'ECCジュニア',
                         description: '全国10,000教室以上の実績ある英会話教室',
                         imageUrl: 'https://via.placeholder.com/300x150/2563eb/white?text=ECCジュニア',
-                        affiliateUrl: 'https://example.com/ecc-junior',
+                        affiliateUrl: 'https://www.eccjr.co.jp/',
                         price: '月額6,600円〜',
                         features: ['2歳から', 'ホームティーチャー制', '無料体験レッスン']
                     },
@@ -1506,7 +1681,7 @@
                         title: 'ペッピーキッズクラブ',
                         description: '楽しく学べる子供英会話教室',
                         imageUrl: 'https://via.placeholder.com/300x150/059669/white?text=ペッピーキッズ',
-                        affiliateUrl: 'https://example.com/peppy-kids',
+                        affiliateUrl: 'https://www.peppykidsclub.com/',
                         price: '月額7,700円〜',
                         features: ['1歳から高校生', '外国人講師', 'オリジナル教材']
                     },
@@ -1514,7 +1689,7 @@
                         title: 'NOVAバイリンガルKIDS',
                         description: '駅前留学でおなじみNOVAの子供向けコース',
                         imageUrl: 'https://via.placeholder.com/300x150/7c2d12/white?text=NOVAキッズ',
-                        affiliateUrl: 'https://example.com/nova-kids',
+                        affiliateUrl: 'https://www.nova.co.jp/',
                         price: '月額8,800円〜',
                         features: ['外国人講師', '少人数制', 'レベル別クラス']
                     }
@@ -1554,7 +1729,7 @@
                         title: 'アトリエ・エトワール',
                         description: '子供の感性を大切にする絵画教室',
                         imageUrl: 'https://via.placeholder.com/300x150/f59e0b/white?text=アトリエエトワール',
-                        affiliateUrl: 'https://example.com/atelier-etoile',
+                        affiliateUrl: 'https://www.atelier-etoile.com/',
                         price: '月額7,700円〜',
                         features: ['少人数制', '個性重視', '作品展示会']
                     },
@@ -1562,7 +1737,7 @@
                         title: 'カルチャーセンター 絵画教室',
                         description: '基礎から学べる絵画レッスン',
                         imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=カルチャー絵画',
-                        affiliateUrl: 'https://example.com/culture-art',
+                        affiliateUrl: 'https://www.culture.gr.jp/',
                         price: '月額5,500円〜',
                         features: ['基礎重視', '画材貸出', '振替レッスン可']
                     }
@@ -1602,7 +1777,7 @@
                         title: 'チャコット・カルチャースタジオ',
                         description: 'バレエ用品で有名なチャコットのスタジオ',
                         imageUrl: 'https://via.placeholder.com/300x150/ec4899/white?text=チャコット',
-                        affiliateUrl: 'https://example.com/chacott-ballet',
+                        affiliateUrl: 'https://www.chacott-jp.com/',
                         price: '月額9,900円〜',
                         features: ['プロ講師陣', '本格レッスン', '発表会あり']
                     },
@@ -1610,7 +1785,7 @@
                         title: 'スタジオマーティ',
                         description: '3歳から始められるバレエ教室',
                         imageUrl: 'https://via.placeholder.com/300x150/8b5cf6/white?text=スタジオマーティ',
-                        affiliateUrl: 'https://example.com/studio-marty',
+                        affiliateUrl: 'https://www.studiomarty.co.jp/',
                         price: '月額7,500円〜',
                         features: ['年齢別クラス', 'RAD認定', '体験レッスン無料']
                     }
@@ -1634,7 +1809,7 @@
                         title: 'EXPG STUDIO',
                         description: 'EXILE・三代目JSBを輩出したダンススクール',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=EXPG',
-                        affiliateUrl: 'https://example.com/expg-studio',
+                        affiliateUrl: 'https://expg.jp/',
                         price: '月額11,000円〜',
                         features: ['プロ輩出実績', 'オーディション', '本格指導']
                     },
@@ -1642,7 +1817,7 @@
                         title: 'NOAダンス教室',
                         description: '都内最大級のダンススタジオ',
                         imageUrl: 'https://via.placeholder.com/300x150/8b5cf6/white?text=NOAダンス',
-                        affiliateUrl: 'https://example.com/noa-dance',
+                        affiliateUrl: 'https://www.noadance.com/',
                         price: '月額8,800円〜',
                         features: ['都内12校', '超入門クラス', '体験レッスン']
                     }
@@ -1667,7 +1842,7 @@
                         title: '劇団ひまわり',
                         description: '子供向け演劇スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/1d4ed8/white?text=劇団ひまわり',
-                        affiliateUrl: 'https://example.com/himawari',
+                        affiliateUrl: 'https://himawari.net/',
                         price: '月額10,000円〜',
                         features: ['実践レッスン', '全国公演', 'オーディション指導']
                     },
@@ -1675,7 +1850,7 @@
                         title: 'テアトルアカデミー',
                         description: '芸能界を目指す子供たちのための総合スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/9333ea/white?text=テアトルアカデミー',
-                        affiliateUrl: 'https://example.com/theatre-academy',
+                        affiliateUrl: 'https://www.theatre.co.jp/',
                         price: '月額12,000円〜',
                         features: ['発声指導', '演技基礎', '発表会']
                     }
@@ -1700,7 +1875,7 @@
                         title: 'マジック教室 MagicLand',
                         description: '初心者からプロ志望まで学べる手品教室',
                         imageUrl: 'https://via.placeholder.com/300x150/f43f5e/white?text=MagicLand',
-                        affiliateUrl: 'https://example.com/magicland',
+                        affiliateUrl: 'https://www.magicland.jp/',
                         price: '月額7,500円〜',
                         features: ['道具貸出', 'ステージ発表', '少人数制']
                     }
@@ -1726,7 +1901,7 @@
                         title: '表千家茶道教室',
                         description: '伝統ある表千家流の正式な茶道指導',
                         imageUrl: 'https://via.placeholder.com/300x150/059669/white?text=表千家',
-                        affiliateUrl: 'https://example.com/omotesenke',
+                        affiliateUrl: 'https://www.omotesenke.jp/',
                         price: '月額8,000円〜',
                         features: ['表千家流', '免状取得可', '和室での本格指導']
                     },
@@ -1734,7 +1909,7 @@
                         title: 'カルチャーセンター 茶道講座',
                         description: '気軽に始められる茶道入門',
                         imageUrl: 'https://via.placeholder.com/300x150/7c3aed/white?text=カルチャー茶道',
-                        affiliateUrl: 'https://example.com/culture-tea',
+                        affiliateUrl: 'https://www.culture.gr.jp/',
                         price: '月額6,000円〜',
                         features: ['初心者歓迎', '道具貸出', '月2回レッスン']
                     }
@@ -1758,7 +1933,7 @@
                         title: '日本棋院 囲碁教室',
                         description: 'プロ棋士による本格指導',
                         imageUrl: 'https://via.placeholder.com/300x150/f59e0b/white?text=日本棋院',
-                        affiliateUrl: 'https://example.com/nihon-kiin',
+                        affiliateUrl: 'https://www.nihonkiin.or.jp/',
                         price: '月額6,600円〜',
                         features: ['プロ棋士指導', '段級位認定', '大会参加可']
                     },
@@ -1766,7 +1941,7 @@
                         title: '子供囲碁教室 石音',
                         description: '子供専門の囲碁教室',
                         imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=石音',
-                        affiliateUrl: 'https://example.com/sekion-go',
+                        affiliateUrl: 'https://sekionigo.com/',
                         price: '月額4,400円〜',
                         features: ['子供専門', '少人数制', '楽しく学習']
                     }
@@ -1790,7 +1965,7 @@
                         title: '日本将棋連盟 子供教室',
                         description: 'プロ棋士による本格将棋指導',
                         imageUrl: 'https://via.placeholder.com/300x150/dc2626/white?text=将棋連盟',
-                        affiliateUrl: 'https://example.com/shogi-renmei',
+                        affiliateUrl: 'https://www.shogi.or.jp/',
                         price: '月額5,500円〜',
                         features: ['プロ棋士指導', '級位認定', '大会参加']
                     },
@@ -1798,7 +1973,7 @@
                         title: 'いつつ将棋教室',
                         description: '子供向け将棋教室の専門スクール',
                         imageUrl: 'https://via.placeholder.com/300x150/8b5cf6/white?text=いつつ',
-                        affiliateUrl: 'https://example.com/itsutsu-shogi',
+                        affiliateUrl: 'https://www.i-tsu-tsu.co.jp/',
                         price: '月額6,600円〜',
                         features: ['子供専門', 'オンライン対応', '楽しく学習']
                     }
@@ -1822,7 +1997,7 @@
                         title: 'ABC Cooking Studio キッズ',
                         description: '子供向け料理・お菓子教室',
                         imageUrl: 'https://via.placeholder.com/300x150/f97316/white?text=ABCキッズ',
-                        affiliateUrl: 'https://example.com/abc-kids',
+                        affiliateUrl: 'https://www.abc-cooking.co.jp/kids/',
                         price: '1回4,500円〜',
                         features: ['全国125スタジオ', '親子参加可', '安全第一']
                     },
@@ -1830,11 +2005,111 @@
                         title: 'ホームメイドクッキング 子供クラス',
                         description: 'パン・ケーキ・料理を総合的に学習',
                         imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=ホームメイド',
-                        affiliateUrl: 'https://example.com/homemade-kids',
+                        affiliateUrl: 'https://www.homemade.co.jp/',
                         price: '月額6,600円〜',
                         features: ['総合料理', '基礎から応用', '季節の料理']
                     }
                 ]
+            },
+
+            calligraphy: {
+                name: '書道',
+                description: '美しい文字を書き集中力と礼儀を学ぶ',
+                category: 'culture',
+                icon: 'fas fa-pen-nib',
+                benefits: ['集中力', '礼儀作法', '表現力', '落ち着き'],
+                cost: '月額4,000円〜8,000円',
+                ageRange: '6歳〜18歳',
+                timeCommitment: '週1回 60分',
+                traits: ['perfectionist', 'cultural'],
+                difficulty: 'medium',
+                continuity_rate: 80,
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "日本習字",
+                        description: "全国展開の書道教室",
+                        imageUrl: "https://via.placeholder.com/300x150/4b5563/white?text=日本習字",
+                        affiliateUrl: "https://www.nihon-shuji.jp/",
+                        price: "月額5,000円〜",
+                        features: ["段位取得", "個別指導", "全国大会"]
+                    }
+                ],
+            },
+
+            chess: {
+                name: 'チェス',
+                description: '国際的なボードゲームで戦略思考を鍛える',
+                category: 'study',
+                icon: 'fas fa-chess-knight',
+                benefits: ['戦略的思考', '計画力', '集中力', '国際感覚'],
+                cost: '月額3,000円〜8,000円',
+                ageRange: '6歳〜18歳',
+                timeCommitment: '週1回 90分',
+                traits: ['logical', 'analyst'],
+                difficulty: 'medium',
+                continuity_rate: 70,
+                future_potential: 'low',
+                affiliateBanners: [
+                    {
+                        title: "日本チェス連盟",
+                        description: "大会情報やレッスンを提供",
+                        imageUrl: "https://via.placeholder.com/300x150/1e40af/white?text=日本チェス連盟",
+                        affiliateUrl: "https://www.japanchess.org/",
+                        price: "月額3,000円〜",
+                        features: ["公認レッスン", "大会参加", "オンライン対局"]
+                    }
+                ],
+            },
+
+            kids_yoga: {
+                name: 'キッズヨガ',
+                description: '柔軟性と集中力を高める子供向けヨガ',
+                category: 'sports',
+                icon: 'fas fa-child',
+                benefits: ['柔軟性', '集中力', '心身の健康', 'リラックス'],
+                cost: '月額5,000円〜10,000円',
+                ageRange: '4歳〜12歳',
+                timeCommitment: '週1回 45分',
+                traits: ['physical', 'gentle'],
+                difficulty: 'easy',
+                continuity_rate: 80,
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "スタジオ・ヨギー キッズヨガ",
+                        description: "専門インストラクターによるキッズヨガ",
+                        imageUrl: "https://via.placeholder.com/300x150/f472b6/white?text=スタジオヨギー",
+                        affiliateUrl: "https://www.studio-yoggy.com/",
+                        price: "月額6,000円〜",
+                        features: ["体験レッスン", "少人数", "オンラインあり"]
+                    }
+                ],
+            },
+
+            camping: {
+                name: 'アウトドアキャンプ',
+                description: '自然の中で生活力と協調性を養う',
+                category: 'sports',
+                icon: 'fas fa-campground',
+                benefits: ['自然体験', '協調性', '自立心', '冒険心'],
+                cost: '1回20,000円〜',
+                ageRange: '8歳〜18歳',
+                timeCommitment: '年数回 2〜3日',
+                traits: ['nature', 'explorer'],
+                difficulty: 'medium',
+                continuity_rate: 65,
+                future_potential: 'medium',
+                affiliateBanners: [
+                    {
+                        title: "日本キャンプ協会",
+                        description: "キャンプ指導者の資格取得も可能",
+                        imageUrl: "https://via.placeholder.com/300x150/065f46/white?text=キャンプ協会",
+                        affiliateUrl: "https://www.camping.or.jp/",
+                        price: "1回20,000円〜",
+                        features: ["自然体験", "安全指導", "団体プログラム"]
+                    }
+                ],
             }
 
             // Note: この例では代表的なものを示しています。実際には150種類すべてを含めます。


### PR DESCRIPTION
## Summary
- fill more affiliate links across tech and sports activities
- include banners for new culture activities like 書道 and チェス
- ensure kids yoga and camping sections have affiliate URLs

## Testing
- `node --check tmp.js` *(passes: object syntax OK)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849edd017b8832eb0248538b3b5e169