### PR TITLE
Add missing affiliate URLs and new 3D modeling activity

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,6 +792,16 @@
                 difficulty: 'medium',
                 continuity_rate: 75,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'Cookpad Do! 親子料理教室',
+                        description: '親子で料理を楽しめるレッスン',
+                        imageUrl: 'https://via.placeholder.com/300x150/ef4444/white?text=Cookpad+Do!',
+                        affiliateUrl: 'https://cookpad.do/',
+                        price: '1回5,000円〜',
+                        features: ['初心者歓迎', '食育講座', 'オンラインあり']
+                    }
+                ],
             },
             early_stem: {
                 name: '幼児STEM教育',
@@ -1062,6 +1072,40 @@
                 difficulty: 'hard',
                 continuity_rate: 70,
                 future_potential: 'very_high'
+                affiliateBanners: [
+                    {
+                        title: 'VCAスクール',
+                        description: 'VR・AR制作が学べる専門スクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/ea580c/white?text=VCA',
+                        affiliateUrl: 'https://vca.tokyo/',
+                        price: '月額15,000円〜',
+                        features: ['最新機材', 'オンライン対応', '作品制作']
+                    }
+                ],
+            },
+            three_d_modeling: {
+                name: '3Dモデリング',
+                description: '3Dソフトを使った立体モデリングの基礎',
+                category: 'technology',
+                icon: 'fas fa-cube',
+                benefits: ['空間認識力', '創造力', '設計力', '将来性'],
+                cost: '月額10,000円〜18,000円',
+                ageRange: '12歳〜18歳',
+                timeCommitment: '週1回 90分',
+                traits: ['creative', 'logical'],
+                difficulty: 'medium',
+                continuity_rate: 70,
+                future_potential: 'very_high',
+                affiliateBanners: [
+                    {
+                        title: 'Tinkercad',
+                        description: '初心者向け3Dモデリングツール',
+                        imageUrl: 'https://via.placeholder.com/300x150/4f46e5/white?text=Tinkercad',
+                        affiliateUrl: 'https://www.tinkercad.com/',
+                        price: '無料〜',
+                        features: ['ブラウザで学習', 'チュートリアル充実', '教育機関向け']
+                    }
+                ]
             },
             digital_art: {
                 name: 'デジタルアート・NFT',
@@ -1414,6 +1458,16 @@
                 difficulty: 'hard',
                 continuity_rate: 75,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'Tokyo Parkour Academy',
+                        description: '本格的なパルクール指導を行うスクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/3b82f6/white?text=Parkour',
+                        affiliateUrl: 'https://parkour.tokyo/',
+                        price: '月額10,000円〜',
+                        features: ['安全指導', '少人数制', '体験レッスン']
+                    }
+                ],
             },
             bouldering: {
                 name: 'ボルダリング・クライミング',
@@ -1428,6 +1482,16 @@
                 difficulty: 'medium',
                 continuity_rate: 80,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'B-PUMP クライミングジム',
+                        description: '初心者から大会志向まで対応するジム',
+                        imageUrl: 'https://via.placeholder.com/300x150/10b981/white?text=B-PUMP',
+                        affiliateUrl: 'https://www.b-pump.com/',
+                        price: '月額8,000円〜',
+                        features: ['設備充実', 'キッズスクール', '体験会']
+                    }
+                ],
             },
             skateboarding: {
                 name: 'スケートボード',
@@ -1442,6 +1506,16 @@
                 difficulty: 'medium',
                 continuity_rate: 75,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'ムラサキスポーツ スケートスクール',
+                        description: '全国展開のスケートボードスクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/7c3aed/white?text=MURASAKI',
+                        affiliateUrl: 'https://www.murasaki.co.jp/',
+                        price: '月額7,000円〜',
+                        features: ['初心者向け', 'レンタルボード', '大会開催']
+                    }
+                ],
             },
             surfing: {
                 name: 'サーフィン',
@@ -1456,6 +1530,16 @@
                 difficulty: 'hard',
                 continuity_rate: 70,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'NSA日本サーフィン連盟',
+                        description: '全国のサーフィンスクール情報を提供',
+                        imageUrl: 'https://via.placeholder.com/300x150/2563eb/white?text=NSA',
+                        affiliateUrl: 'https://www.nsa-surf.org/',
+                        price: '月額12,000円〜',
+                        features: ['公認インストラクター', '大会情報', '体験レッスン']
+                    }
+                ],
             },
             bmx: {
                 name: 'BMX',
@@ -1470,6 +1554,16 @@
                 difficulty: 'hard',
                 continuity_rate: 70,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: 'JBMXF公認スクール',
+                        description: '日本BMX連盟による公式スクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/f59e0b/white?text=BMX',
+                        affiliateUrl: 'https://www.jbmxa.com/',
+                        price: '月額9,000円〜',
+                        features: ['公認コーチ', '大会参加', '体験レッスン']
+                    }
+                ],
             },
 
                         // 武道系 (10種類) - 年齢範囲修正
@@ -1756,6 +1850,16 @@
                 difficulty: 'medium',
                 continuity_rate: 75,
                 future_potential: 'medium'
+                affiliateBanners: [
+                    {
+                        title: '陶芸工房 陶芸教室',
+                        description: '初心者から学べる陶芸スクール',
+                        imageUrl: 'https://via.placeholder.com/300x150/fbbf24/white?text=陶芸工房',
+                        affiliateUrl: 'https://www.tougei-kobo.com/',
+                        price: '月額8,000円〜',
+                        features: ['道具レンタル', '少人数制', '体験レッスン']
+                    }
+                ],
             },
             
             // ダンス・パフォーマンス系 (15種類) - 年齢範囲修正


### PR DESCRIPTION
## Summary
- add affiliate banners to several activities
- include a new "3Dモデリング" activity in the technology category

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849f8b6002c832e95683c10d9625645